### PR TITLE
Upgrade to new plugin registration

### DIFF
--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -6,6 +6,7 @@
 .DS_Store
 /build
 /captures
+GeneratedPluginRegistrant.java
 
 /gradle
 /gradlew

--- a/example/android/app/src/main/java/io/flutter/plugins/.gitignore
+++ b/example/android/app/src/main/java/io/flutter/plugins/.gitignore
@@ -1,1 +1,0 @@
-PluginRegistry.java

--- a/example/android/app/src/main/java/io/flutter/plugins/firebase_messaging_example/MainActivity.java
+++ b/example/android/app/src/main/java/io/flutter/plugins/firebase_messaging_example/MainActivity.java
@@ -7,20 +7,12 @@ package io.flutter.plugins.firebase_messaging_example;
 import android.content.Intent;
 import android.os.Bundle;
 import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.PluginRegistry;
+import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
-  PluginRegistry pluginRegistry;
-
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    pluginRegistry = new PluginRegistry();
-    pluginRegistry.registerAll(this);
-  }
-
-  @Override
-  protected void onNewIntent(Intent intent) {
-    pluginRegistry.firebase_messaging.onNewIntent(intent);
+    GeneratedPluginRegistrant.registerWith(this);
   }
 }


### PR DESCRIPTION
This change should make sense once the new plugin registration of https://github.com/flutter/flutter/pull/9715 has landed.

The change involves making the plugin constructor simple (just setting fields), leaving it to the static registration method to publish the fully created plugin instance.